### PR TITLE
🐛 fix: Enables the systemd-timesyncd service for gnome, xfce, and cin…

### DIFF
--- a/bigcommunity/cinnamon/profile.conf
+++ b/bigcommunity/cinnamon/profile.conf
@@ -43,7 +43,7 @@ geoip='true'
 # unset defaults to given values
 # names must match systemd service names
 #enable_systemd=('bluetooth' 'cronie' 'ModemManager' 'NetworkManager' 'cups' 'haveged' 'fstrim.timer' 'pkgfile-update.timer')
-enable_systemd=('bluetooth' 'cronie' 'ModemManager' 'NetworkManager' 'cups' 'fstrim.timer' 'pkgfile-update.timer' 'vboxservice' 'bluetooth' 'avahi-daemon' 'smb' 'cups-browsed')
+enable_systemd=('bluetooth' 'cronie' 'ModemManager' 'NetworkManager' 'cups' 'fstrim.timer' 'pkgfile-update.timer' 'vboxservice' 'bluetooth' 'avahi-daemon' 'smb' 'cups-browsed' 'systemd-timesyncd')
 #disable_systemd=('avahi-daemon' 'pacman-init')
 #disable_systemd=('avahi-daemon' 'pacman-init')
 

--- a/bigcommunity/gnome/profile.conf
+++ b/bigcommunity/gnome/profile.conf
@@ -44,7 +44,7 @@ geoip='true'
 # unset defaults to given values
 # names must match systemd service names
 #enable_systemd=('bluetooth' 'cronie' 'ModemManager' 'NetworkManager' 'cups' 'haveged' 'fstrim.timer' 'pkgfile-update.timer')
-enable_systemd=('bluetooth' 'cronie' 'ModemManager' 'NetworkManager' 'cups' 'fstrim.timer' 'pkgfile-update.timer' 'vboxservice' 'ufw' 'avahi-daemon' 'smb' 'cups-browsed')
+enable_systemd=('bluetooth' 'cronie' 'ModemManager' 'NetworkManager' 'cups' 'fstrim.timer' 'pkgfile-update.timer' 'vboxservice' 'ufw' 'avahi-daemon' 'smb' 'cups-browsed' 'systemd-timesyncd')
 #disable_systemd=('avahi-daemon' 'pacman-init')
 #disable_systemd=('avahi-daemon' 'pacman-init')
 

--- a/bigcommunity/xfce/profile.conf
+++ b/bigcommunity/xfce/profile.conf
@@ -44,7 +44,7 @@ geoip='true'
 # unset defaults to given values
 # names must match systemd service names
 #enable_systemd=('bluetooth' 'cronie' 'ModemManager' 'NetworkManager' 'cups' 'haveged' 'fstrim.timer' 'pkgfile-update.timer')
-enable_systemd=('systemd-timesyncd' 'bluetooth' 'cronie' 'ModemManager' 'NetworkManager' 'cups' 'vboxservice' 'ufw' 'avahi-daemon' 'smb' 'cups-browsed')
+enable_systemd=('systemd-timesyncd' 'bluetooth' 'cronie' 'ModemManager' 'NetworkManager' 'cups' 'vboxservice' 'ufw' 'avahi-daemon' 'smb' 'cups-browsed' 'systemd-timesyncd')
 enable_systemd_timers=(pkgfile-update.timer fstrim.timer)
 #disable_systemd=('avahi-daemon' 'pacman-init')
 #disable_systemd=('avahi-daemon' 'pacman-init')


### PR DESCRIPTION
…namon.